### PR TITLE
fix: make loading animation logo much smaller on mobile

### DIFF
--- a/components/ui/loading-animation.tsx
+++ b/components/ui/loading-animation.tsx
@@ -41,9 +41,9 @@ export function LoadingAnimation({ onComplete }: LoadingAnimationProps) {
           transition={{ duration: 0.8, ease: "easeInOut" }}
           className="fixed inset-0 z-50 w-full h-full theme-bg-primary flex items-center justify-center"
         >
-          {/* Video Container - Full Screen */}
+          {/* Video Container - Responsive sizing */}
           <motion.div 
-            className="relative w-full h-full"
+            className="relative w-full h-full flex items-center justify-center"
             initial={{ scale: 0.8, opacity: 0 }}
             animate={{ scale: 1, opacity: 1 }}
             transition={{ duration: 0.6, ease: "easeOut" }}
@@ -53,7 +53,7 @@ export function LoadingAnimation({ onComplete }: LoadingAnimationProps) {
               muted
               loop={false}
               playsInline
-              className="w-full h-full object-cover md:object-cover object-contain"
+              className="w-auto h-[50vh] md:w-full md:h-full object-contain md:object-cover"
               onEnded={handleVideoEnd}
               onLoadedData={() => console.log('Video loaded successfully')}
               onError={(e) => console.error('Video failed to load:', e)}


### PR DESCRIPTION
- Set video height to 50vh on mobile to reduce logo size
- Keep full width visible without cutting sides
- Maintain full screen on desktop
- Use object-contain on mobile for proper aspect ratio

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the loading animation's responsiveness across all screen sizes. The video element now features adaptive sizing with improved centering, intelligent scaling behavior that adjusts based on device dimensions, and refined aspect ratio handling for optimal visual presentation on both compact and larger displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->